### PR TITLE
fix: wrong invocation of url in README.md tutorial

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ from geoserver import GeoServer
 
 # Connect to a GeoServer instance
 geoserver = GeoServer(
-    url="http://localhost:8080/geoserver",
+    service_url="http://localhost:8080/geoserver",
     username="admin",
     password="geoserver"
 )


### PR DESCRIPTION
fix: wrong invocation of url in README.md tutorial. Made this to service_url instead of url.